### PR TITLE
Accept slashes on branch names

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -21,7 +21,7 @@ import subprocess
 VERSION = '0.2+'
 DEBUG = False
 
-tag_version_re = re.compile(r'^[a-zA-Z0-9_\-\.]+-v(\d+)$')
+tag_version_re = re.compile(r'^[a-zA-Z0-9_/\-\.]+-v(\d+)$')
 
 # As a git alias it is helpful to be a single file script with no external
 # dependencies, so these git command-line wrappers are used instead of


### PR DESCRIPTION
git-publish works but gets confused when the branch name I am working on contains slashes. Git happily accepts tags and branches names containing slashes, so the tags were properly created. But the `--edit` command got confused because `get_latest_tag_number()` couldn't get the latest tag number from the git tag list.
