### PR TITLE
Use core.editor to determine editor

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -164,11 +164,13 @@ def get_number_of_commits(base):
     return len(git_log('%s..' % base))
 
 def edit(filename):
-    editor = 'vi'
-    for envvar in 'VISUAL', 'EDITOR':
-        if envvar in os.environ:
-            editor = os.environ[envvar]
-            break
+    editor = git_get_config('core', 'editor')
+    if not editor:
+        editor = 'vi'
+        for envvar in 'VISUAL', 'EDITOR':
+            if envvar in os.environ:
+                editor = os.environ[envvar]
+                break
     subprocess.call([editor, filename])
 
 def tag(name, template, annotate=False, force=False):


### PR DESCRIPTION
Using git's core.editor variable to determine the editor in the first instance is more git-ish IMHO
