### PR TITLE
Run on python2 by default

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # git-publish - Prepare and store patch revisions as git tags
 #


### PR DESCRIPTION
On systems where Python 3 is the default one, git-publish will fail when
ran due to different syntax.  Using python2 in shebang fixes the problem.

Signed-off-by: Martin Kletzander mkletzan@redhat.com
