### PR TITLE
More profile opts

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -310,8 +310,8 @@ def tag(name, template, annotate=False, force=False, sign=False):
 
 def send_email(to_list, cc_list, prefix, base, message, annotate, signoff,
                inspect_emails, suppress_cc):
-    numbered = get_number_of_commits(base) > 1
     cover_letter = bool(message)
+    numbered = get_number_of_commits(base) > 1 or cover_letter
     revlist = '%s..' % base
 
     try:


### PR DESCRIPTION
Add --signoff and --inspect-emails to profile settings for the accident prone. (Me.)
Force numbering of patch series if there's a cover letter.
Fix a print bug from the profile patch.
