### PR TITLE
Don't make new versioned tag when in --edit mode

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -566,10 +566,10 @@ def main():
         git_set_config('branch', topic, 'gitpublishto', to)
         git_set_config('branch', topic, 'gitpublishcc', cc)
 
-    if not options.pull_request:
-        # Publishing is done, stablize the tag now
-        _git("tag", tag_name(topic, number), tag_name_staging(topic))
-        git_delete_tag(tag_name_staging(topic))
+        if not options.pull_request:
+            # Publishing is done, stablize the tag now
+            _git("tag", tag_name(topic, number), tag_name_staging(topic))
+            git_delete_tag(tag_name_staging(topic))
 
     return 0
 


### PR DESCRIPTION
commit 0abb1fbb4f92ab2f86f764767cec5956e944f1bb made
`git publish --edit` always create a new versioned tag. Fix it so we
create a new tag only when actually publishing the code.

Cc: @famz 
