### PR TITLE
Cascading CC options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -222,6 +222,13 @@ want to send a new version to both new@example.org and old@example.org::
 
   $ git-publish --cc old@example.org
 
+To temporarily ignore any CCs in the profile or saved list, and send only to
+the addresses specified on the CLI::
+
+  $ git-publish --override-cc --cc onetime@example.org --to patches@example.org
+
+CCs specified alongside --override-cc are not remembered for future revisions.
+
 Creating profiles for frequently used projects
 ==============================================
 

--- a/README.rst
+++ b/README.rst
@@ -209,6 +209,19 @@ customizing the Subject: line::
 
   $ git publish --to patches@example.org --subject-prefix RFC
 
+git-publish remembers the list of addresses CC'd on previous revisions
+of a patchset by default. To clear that internal list::
+
+  $ git publish --to patches@example.org --forget-cc --cc new@example.org
+
+In the above example, new@example.org will be saved to the internal list
+for next time.
+
+CC addresses accumulate and cascade. Following the previous example, if we
+want to send a new version to both new@example.org and old@example.org::
+
+  $ git-publish --cc old@example.org
+
 Creating profiles for frequently used projects
 ==============================================
 

--- a/git-publish
+++ b/git-publish
@@ -433,6 +433,8 @@ def main():
                       help='add Signed-off-by: <self> to commits when emailing')
     parser.add_option('--suppress-cc', dest='suppress_cc',
                       help='override auto-cc when sending email (man git-send-email for details)')
+    parser.add_option('--forget-cc', dest='forget_cc', action='store_true',
+                      default=False, help='Forget all previous CC emails')
 
     options, args = parser.parse_args()
 
@@ -484,6 +486,9 @@ def main():
         to = git_get_config_list('branch', topic, 'gitpublishto')
         if not to:
             to = get_profile_var_list(options.profile_name, 'to')
+
+    if options.forget_cc:
+        git_set_config('branch', topic, 'gitpublishcc', [])
 
     cc = set(options.cc)
     if not options.edit:

--- a/git-publish
+++ b/git-publish
@@ -435,6 +435,8 @@ def main():
                       help='override auto-cc when sending email (man git-send-email for details)')
     parser.add_option('--forget-cc', dest='forget_cc', action='store_true',
                       default=False, help='Forget all previous CC emails')
+    parser.add_option('--override-cc', dest='override_cc', action='store_true',
+                      default=False, help='Ignore any profile or saved CC emails')
 
     options, args = parser.parse_args()
 
@@ -491,7 +493,7 @@ def main():
         git_set_config('branch', topic, 'gitpublishcc', [])
 
     cc = set(options.cc)
-    if not options.edit:
+    if not options.edit and not options.override_cc:
         cc = cc.union(git_get_config_list('branch', topic, 'gitpublishcc'))
         cc = cc.union(get_profile_var_list(options.profile_name, 'cc'))
 
@@ -570,7 +572,8 @@ def main():
 
         # Store --to and --cc for next revision
         git_set_config('branch', topic, 'gitpublishto', to)
-        git_set_config('branch', topic, 'gitpublishcc', cc)
+        if not options.override_cc:
+            git_set_config('branch', topic, 'gitpublishcc', cc)
 
         if not options.pull_request:
             # Publishing is done, stablize the tag now

--- a/git-publish
+++ b/git-publish
@@ -81,7 +81,7 @@ def git_set_config(*components):
     val = components[-1]
     name = '.'.join(components[:-1])
 
-    if isinstance(val, list) or isinstance(val, tuple):
+    if hasattr(val, '__iter__'):
         _git('config', '--unset-all', name)
         for v in val:
             _git('config', '--add', name, v)
@@ -485,11 +485,10 @@ def main():
         if not to:
             to = get_profile_var_list(options.profile_name, 'to')
 
-    cc = options.cc
-    if not cc and not options.edit:
-        cc = git_get_config_list('branch', topic, 'gitpublishcc')
-        if not cc:
-            cc = get_profile_var_list(options.profile_name, 'cc')
+    cc = set(options.cc)
+    if not options.edit:
+        cc = cc.union(git_get_config_list('branch', topic, 'gitpublishcc'))
+        cc = cc.union(get_profile_var_list(options.profile_name, 'cc'))
 
     if options.pull_request:
         remote = git_get_config('branch', topic, 'remote')


### PR DESCRIPTION
Hi Stefan:

The first patch changes CC options to cascade between profile, history, and CLI.
Patch 2 adds a flag to delete Saved CCs.
Patch 3 adds a flag to overwrite Saved and Profile CCs with CLI CCs.

This is to allow profiles with built-in CC options to cascade with Command Line options. For example: a qemu-block profile might specify:

[gitpublishprofile "block"]
to = qemu-block@nongnu.org
cc = qemu-devel@nongnu.org

but we'd still like to be able to specify additional CC options on the command-line, so allowing them to cascade is useful.

Take what seems useful, NACK what doesn't. :octocat: