### PR TITLE
Fix $GIT_EDITOR invocation if it has whitespace

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -291,7 +291,7 @@ def get_number_of_commits(base):
     return len(git_log('%s..' % base))
 
 def edit(*filenames):
-    cmd = [git_get_var('GIT_EDITOR')]
+    cmd = git_get_var('GIT_EDITOR').split(" ")
     cmd.extend(filenames)
     subprocess.call(cmd)
 


### PR DESCRIPTION
If GIT_EDITOR is "emacs -nw" (containing a whitespace),
subcommand.call() will fail.

Split the variable with whitespace.

Reported by: David Gibson <dgibson@redhat.com>
Signed-off-by: Fam Zheng <famz@redhat.com>