### PR TITLE
Ignore the default "." remote

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -502,7 +502,7 @@ def main():
 
     if options.pull_request:
         remote = git_get_config('branch', topic, 'remote')
-        if remote is None:
+        if remote is None or remote == '.':
             remote = get_profile_var(options.profile_name, 'remote')
         if remote is None:
             print 'Please set git config branch.%s.remote' % topic


### PR DESCRIPTION
Git branches created with "git checkout -b $BRANCH" command has a
default "." remote in .git/config. When sending pull requests in such a
branch, the per profile remote setting is masked.

Such a remote is obviously meaningless for pull requests, so simply
ignore it and fall through to the profile var if any.

Signed-off-by: Fam Zheng <famz@redhat.com>