### PR TITLE
Support "format.subjectprefix" in git-format-patch

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -544,7 +544,7 @@ def main():
         if options.pull_request:
             prefix = 'PULL'
         else:
-            prefix = 'PATCH'
+            prefix = git_get_config('format', 'subjectprefix') or 'PATCH'
     if number > 1:
         prefix = '%s v%d' % (prefix, number)
 


### PR DESCRIPTION
This is a parameter known by git-format-patch command. Since we still
don't have a per-repository way to store subject prefix for series,
it'll be good to have it.

Another natural benefit for this: git-publish naturally becomes
compatible with git-format-patch. For example, if people just switched
to use git-publish from originall git-format-patch, they would not need
to bother specify subject prefix again.

Here "format.subjectprefix" is having the lowest priority to make sure
old git-publish users (with profiles) are not affected.

Signed-off-by: Peter Xu <peterx@redhat.com>