### PR TITLE
Add --notes options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -238,6 +238,15 @@ the addresses specified on the CLI::
 
 CCs specified alongside --override-cc are not remembered for future revisions.
 
+  $ git publish --to patches@example.org --notes
+
+To include git-notes into a patch.
+
+One can attach notes to a commit with `git notes add <object>`. For having the
+notes "following" a commit on rebase operation, you can use
+`git config notes.rewriteRef refs/notes/commits`. For more information,
+give a look at git-notes(1).
+
 Creating profiles for frequently used projects
 ==============================================
 
@@ -275,6 +284,7 @@ The following profile options are available::
   message = true              # same as --message
   signoff = true              # same as --signoff
   inspect-emails = true       # same as --inspect-emails
+  notes = true                # same as --notes
 
 The special "default" profile name is active when no --profile command-line
 option was given.  The default profile does not set any options but can be

--- a/git-publish
+++ b/git-publish
@@ -167,7 +167,8 @@ def git_tag(name, annotate=None, force=False, sign=False):
     _git_check(*args)
 
 def git_format_patch(revlist, subject_prefix=None, output_directory=None,
-                     numbered=False, cover_letter=False, signoff=False):
+                     numbered=False, cover_letter=False, signoff=False,
+                     notes=False):
     args = ['format-patch']
     if subject_prefix:
         args += ['--subject-prefix', subject_prefix]
@@ -181,6 +182,8 @@ def git_format_patch(revlist, subject_prefix=None, output_directory=None,
         args += ['--no-cover-letter']
     if signoff:
         args += ['--signoff']
+    if notes:
+        args += ['--notes']
     args += [revlist]
     _git_check(*args)
 
@@ -502,6 +505,9 @@ def parse_args():
     parser.add_option('-s', '--signoff', dest='signoff', action='store_true',
                       default=False,
                       help='add Signed-off-by: <self> to commits when emailing')
+    parser.add_option('--notes', dest='notes', action='store_true',
+                      default=False,
+                      help='Append the notes (see git-notes(1)) for the commit after the three-dash line.')
     parser.add_option('--suppress-cc', dest='suppress_cc',
                       help='override auto-cc when sending email (man git-send-email for details)')
     parser.add_option('-v', '--verbose', dest='verbose',
@@ -671,6 +677,11 @@ gitpublishprofile.%s.remote''' % (topic, topic, options.profile_name)
         else:
             inspect_emails = get_profile_var(options.profile_name, 'inspect-emails')
 
+        if options.notes:
+            notes = True
+        else:
+            notes = get_profile_var(options.profile_name, 'notes')
+
         try:
             tmpdir = tempfile.mkdtemp()
             numbered = get_number_of_commits(base) > 1 or message
@@ -679,7 +690,8 @@ gitpublishprofile.%s.remote''' % (topic, topic, options.profile_name)
                              output_directory=tmpdir,
                              numbered=numbered,
                              cover_letter=message,
-                             signoff=signoff)
+                             signoff=signoff,
+                             notes=notes)
             if message:
                 cover_letter_path = os.path.join(tmpdir, '0000-cover-letter.patch')
                 lines = open(cover_letter_path).readlines()


### PR DESCRIPTION
This is to use --notes of git format-patch. It includes git-notes(1)
into the patch description, after the three-dash line ---.

Signed-off-by: Anthony PERARD <anthony.perard@citrix.com>