### PR TITLE
smarter push default resolution

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -277,6 +277,7 @@ The following profile options are available::
   [gitpublishprofile "example"]
   base = v2.1.0               # same as --base
   remote = origin             # used if branch.<branch-name>.remote not set
+  pushremote = origin         # Overrides git settings as default push target
   prefix = PATCH              # same as --patch
   to = patches@example.org    # same as --to
   cc = maintainer@example.org # same as --cc

--- a/git-publish
+++ b/git-publish
@@ -25,6 +25,7 @@ from email import message_from_file, header
 VERSION = '1.3'
 
 tag_version_re = re.compile(r'^[a-zA-Z0-9_/\-\.]+-v(\d+)$')
+remote_name_re = re.compile(r'^refs/remotes/(.*?)/.*$')
 
 # As a git alias it is helpful to be a single file script with no external
 # dependencies, so these git command-line wrappers are used instead of
@@ -146,6 +147,20 @@ def git_get_tag_message(tag):
             return message
         message.append(line)
     return None
+
+def git_get_remote_from_refspec(refspec):
+    pushref = _git('rev-parse', '--symbolic-full-name', refspec)
+    if not pushref:
+        return None
+    match = remote_name_re.match(pushref[0])
+    if not match:
+        return None
+    return match.group(1)
+
+def git_get_push_remote(topic = None):
+    if topic is None:
+        topic = git_get_current_branch()
+    return git_get_remote_from_refspec('%s@{push}' % topic)
 
 def git_get_push_remote_approx(topic = None):
     if topic is None:
@@ -611,7 +626,9 @@ def main():
                  get_profile_var(options.profile_name, 'cccmd')
 
     if options.pull_request:
-        remote = git_get_push_remote_approx(topic)
+        remote = git_get_push_remote(topic)
+        if remote is None or remote == '.':
+            remote = git_get_push_remote_approx(topic)
         if remote is None or remote == '.':
             remote = get_profile_var(options.profile_name, 'remote')
         if remote is None:

--- a/git-publish
+++ b/git-publish
@@ -626,7 +626,9 @@ def main():
                  get_profile_var(options.profile_name, 'cccmd')
 
     if options.pull_request:
-        remote = git_get_push_remote(topic)
+        remote = get_profile_var(options.profile_name, 'pushremote')
+        if remote is None:
+            remote = git_get_push_remote(topic)
         if remote is None or remote == '.':
             remote = git_get_push_remote_approx(topic)
         if remote is None or remote == '.':

--- a/git-publish
+++ b/git-publish
@@ -147,6 +147,16 @@ def git_get_tag_message(tag):
         message.append(line)
     return None
 
+def git_get_push_remote_approx(topic = None):
+    if topic is None:
+        topic = git_get_current_branch()
+    remote = git_get_config('branch', topic, 'pushRemote')
+    if remote is None:
+        remote = git_get_config('remote', 'pushDefault')
+    if remote is None:
+        remote = git_get_config('branch', topic, 'remote')
+    return remote
+
 def git_request_pull(base, remote, signed_tag):
     return _git_check('request-pull', base, remote, signed_tag)
 
@@ -601,11 +611,7 @@ def main():
                  get_profile_var(options.profile_name, 'cccmd')
 
     if options.pull_request:
-        remote = git_get_config('branch', topic, 'pushRemote')
-        if remote is None:
-            remote = git_get_config('remote', 'pushDefault')
-        if remote is None:
-            remote = git_get_config('branch', topic, 'remote')
+        remote = git_get_push_remote_approx(topic)
         if remote is None or remote == '.':
             remote = get_profile_var(options.profile_name, 'remote')
         if remote is None:


### PR DESCRIPTION
git-publish's current method of determining the push remote is only approximate and does not necessarily take into account the full semantics of triangular workflows as git's native configuration might.

To this end, teach git-publish to query git for the "real" push target so that git-publish more closely integrates with git in a natural way consistent with native config.

Lastly, if mirroring the actual git behavior breaks existing workflows with git-publish, offer a new override functionality that allows us to specify that our publish target should remain distinct from our push target (say, for instance, if we wish to publish against origin/master but push to jsmith/topic.)

This differs from the existing `remote` field in that this one takes precedence and is not used as a backup or default.