### PR TITLE
Fix encoding of cc_cmd

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -718,7 +718,7 @@ gitpublishprofile.%s.remote''' % (topic, topic, options.profile_name))
             if cc_cmd:
                 for x in patches:
                     output = subprocess.check_output(cc_cmd + " " + x,
-                                shell=True)
+                                shell=True).decode("utf-8")
                     cc = cc.union(output.splitlines())
             cc.difference_update(to)
             if inspect_emails:


### PR DESCRIPTION
The cc we've got so far is a list of unicode strings, but here the
output is raw string (byte array). The following union operation
shouldn't mix these two types. Explicitly decode it like in
popen_lines().

Reported-by: Peter Xu <peterx@redhat.com>
Signed-off-by: Fam Zheng <famz@redhat.com>