### PR TITLE
Fix edit_email_list

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -407,8 +407,8 @@ def parse_header(hdr):
         return hdr
 
 def edit_email_list(cc_list):
-    tmpfile = tempfile.NamedTemporaryFile(mode='w', suffix='.txt')
-    tmpfile.write(os.linesep.join(cc_list))
+    tmpfile = tempfile.NamedTemporaryFile(mode='wb', suffix='.txt')
+    tmpfile.write(os.linesep.join(cc_list).encode('utf-8'))
     tmpfile.flush()
     edit(tmpfile.name)
     r = []


### PR DESCRIPTION
With Python 2, file.write implicitly tries to encode the joined list as
'ascii' which will not work if there are non-ascii being written.

Be explicit with the encoding to fix that.

Signed-off-by: Fam Zheng <famz@redhat.com>