### PR TITLE
add "s" menu command

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -451,6 +451,7 @@ def inspect_menu(tmpdir, to_list, cc_list, patches, suppress_cc, in_reply_to,
                 ('c', 'Edit Cc list in editor (save after edit)'),
                 ('t', 'Edit To list in editor (save after edit)'),
                 ('e', 'Edit patches in editor'),
+                ('s', 'Select patches to send (default: all)'),
                 ('p', 'Print final email headers (dry run)'),
                 ('a', 'Send all'),
                 ('q', 'Cancel (quit)'),
@@ -469,6 +470,13 @@ def inspect_menu(tmpdir, to_list, cc_list, patches, suppress_cc, in_reply_to,
             git_save_email_lists(topic, to_list, cc_list, override_cc)
         elif a == 'e':
             edit(*patches)
+        elif a == 's':
+            listfile = tempfile.NamedTemporaryFile()
+            listfile.write("\n".join(patches))
+            listfile.flush()
+            edit(listfile.name)
+            listfile.seek(0)
+            patches = [x for x in listfile.read().splitlines() if len(x.strip())]
         elif a == 'p':
             print('\n'.join(output))
         elif a == 'a':


### PR DESCRIPTION
In rare cases we need to select which patches to send instead of all.
One example is the revised pull requests in QEMU which may omit the
unchanged patches.

Signed-off-by: Fam Zheng <famz@redhat.com>