### PR TITLE
Encoding tag annotate tmpfile with utf-8

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -376,7 +376,7 @@ def tag(name, template, annotate=False, force=False, sign=False):
     try:
         if annotate:
             fd, tmpfile = tempfile.mkstemp(text=True)
-            os.fdopen(fd, 'w').write(os.linesep.join(template + ['']))
+            os.fdopen(fd, 'wb').write(os.linesep.join(template + ['']).encode('utf-8'))
             edit(tmpfile)
 
         git_tag(name, annotate=tmpfile, force=force, sign=sign)


### PR DESCRIPTION
The default ascii encoding will raise exceptions if there are non-ascii
chars in the template.
```
Traceback (most recent call last):
  File "/home/fam/bin/git-publish", line 767, in <module>
    sys.exit(main())
  File "/home/fam/bin/git-publish", line 663, in main
    tag(tag_name_staging(topic), tag_message, annotate=anno, force=True)
  File "/home/fam/bin/git-publish", line 379, in tag
    os.fdopen(fd, 'wb').write(os.linesep.join(template + ['']).encode())
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 139: ordinal not in range(128)
```