### PR TITLE
debian: use backports-compatible debhelper version

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Philippe Mathieu-Daudé <f4bug@amsat.org>
 Section: vcs
 Priority: optional
 Build-Depends-Indep:
- debhelper (>= 11),
+ debhelper (>= 11~),
  dh-python,
  python:any,
 Standards-Version: 4.1.3


### PR DESCRIPTION
debhelper 11 is already in stretch-backports, but backports packages are always ordered between stable and stable+1 versions via the ~bpo9 suffix.

adding the ~ allows backported debhelper 11 packages to fulfill the versioned dependency, allowing for no-change backports.

Signed-off-by: Fabian Grünbichler <f.gruenbichler@proxmox.com>