### PR TITLE
check for errors when getting toplevel dir

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -127,7 +127,7 @@ GIT_TOPLEVEL = None
 def git_get_toplevel_dir():
     global GIT_TOPLEVEL
     if GIT_TOPLEVEL is None:
-        GIT_TOPLEVEL = _git('rev-parse', '--show-toplevel')[0]
+        GIT_TOPLEVEL = _git_check('rev-parse', '--show-toplevel')[0]
     return GIT_TOPLEVEL
 
 GIT_DIR = None


### PR DESCRIPTION
when running "git publish" outside of a repository this makes the
difference between

```
  ...
  File "/usr/bin/git-publish", line 130, in git_get_toplevel_dir
    GIT_TOPLEVEL = _git('rev-parse', '--show-toplevel')[0]
IndexError: list index out of range
```

and

```
  ...
  File "git-publish/git-publish", line 130, in git_get_toplevel_dir
    GIT_TOPLEVEL = _git_check('rev-parse', '--show-toplevel')[0]
  File "git-publish/git-publish", line 63, in _git_check
    raise GitError('\n'.join(stderr))
__main__.GitError: fatal: Not a git repository (or any parent up to mount point /foo/bar)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```

Signed-off-by: Fabian Grünbichler <f.gruenbichler@proxmox.com>