### PR TITLE
Merge "TO" list for various configurations

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -612,12 +612,10 @@ def main():
     else:
         number = get_latest_tag_number(topic) + 1
 
-    to = options.to
-    if not to and not options.edit:
-        to = git_get_config_list('branch', topic, 'gitpublishto')
-        if not to:
-            to = get_profile_var_list(options.profile_name, 'to')
-    to = set(to)
+    to = set(options.to)
+    if not options.edit:
+        to = to.union(git_get_config_list('branch', topic, 'gitpublishto'))
+        to = to.union(get_profile_var_list(options.profile_name, 'to'))
 
     if options.forget_cc:
         git_set_config('branch', topic, 'gitpublishcc', [])

--- a/git-publish
+++ b/git-publish
@@ -550,6 +550,8 @@ def parse_args():
                       help='show executed git commands (useful for troubleshooting)')
     parser.add_option('--forget-cc', dest='forget_cc', action='store_true',
                       default=False, help='Forget all previous CC emails')
+    parser.add_option('--override-to', dest='override_to', action='store_true',
+                      default=False, help='Ignore any profile or saved TO emails')
     parser.add_option('--override-cc', dest='override_cc', action='store_true',
                       default=False, help='Ignore any profile or saved CC emails')
     parser.add_option('--in-reply-to', "-R",
@@ -613,7 +615,7 @@ def main():
         number = get_latest_tag_number(topic) + 1
 
     to = set(options.to)
-    if not options.edit:
+    if not options.edit and not options.override_to:
         to = to.union(git_get_config_list('branch', topic, 'gitpublishto'))
         to = to.union(get_profile_var_list(options.profile_name, 'to'))
 

--- a/git-publish.pod
+++ b/git-publish.pod
@@ -161,6 +161,10 @@ Show executed git commands (useful for troubleshooting).
 
 Forget all previous Cc: email addresses.
 
+=item B<--override-to>
+
+Ignore any profile or saved To: email addresses.
+
 =item B<--override-cc>
 
 Ignore any profile or saved Cc: email addresses.


### PR DESCRIPTION
We can provide "TO" in three places:

- using "--to" parameter
- using "--profile" or "-p" and setup "TO" in the profiles
- using saved "TO" list in git config

For "CC" list we merge them.  For "TO" list we didn't.  Let's do the
same for "TO" list so that we always merge the "TO"s in all configs.

Signed-off-by: Peter Xu <peterx@redhat.com>