### PR TITLE
Adding blurb-template option to git-publish

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -496,6 +496,8 @@ def parse_args():
                       default=False, help='review and edit each patch email')
     parser.add_option('-b', '--base', dest='base', default=None,
                       help='branch which this is based off [defaults to master]')
+    parser.add_option('--blurb-template', dest='blurb_template', default=None,
+                      help='Template for blurb [defaults to *** BLURB HERE ***]')
     parser.add_option('--cc', dest='cc', action='append', default=[],
                       help='specify a Cc: email recipient')
     parser.add_option('--cc-cmd',
@@ -632,6 +634,12 @@ def main():
         cc_cmd = git_get_config('branch', topic, 'gitpublishcccmd') or \
                  get_profile_var(options.profile_name, 'cccmd')
 
+    blurb_template = options.blurb_template
+    if not blurb_template:
+        blurb_template = '\n'.join(get_profile_var_list(options.profile_name, 'blurb-template'))
+    if not blurb_template:
+        blurb_template = "*** BLURB HERE ***"
+
     if options.pull_request:
         remote = git_get_config('branch', topic, 'pushRemote')
         if remote is None:
@@ -702,7 +710,7 @@ branch.%s.pushRemote is set appropriately?  (Override with --no-url-check)''' % 
         tag_message = get_latest_tag_message(topic, [
             '*** SUBJECT HERE ***',
             '',
-            '*** BLURB HERE ***'])
+            blurb_template])
         anno = options.edit or message
         tag(tag_name_staging(topic), tag_message, annotate=anno, force=True)
 

--- a/git-publish.pod
+++ b/git-publish.pod
@@ -113,6 +113,10 @@ Sign tag when sending pull request.
 
 Do not sign tag when sending pull request.
 
+=item B<--blurb-template>
+
+Use a pre-defined blurb message for the series HEAD.
+
 =item B<--subject-prefix=PREFIX>
 
 Set the email Subject: header prefix.
@@ -414,16 +418,17 @@ command-line options take precedence.
 The following profile options are available:
 
   [gitpublishprofile "example"]
-  base = v2.1.0               # same as --base
-  remote = origin             # used if branch.<branch-name>.remote not set
-  prefix = PATCH              # same as --patch
-  to = patches@example.org    # same as --to
-  cc = maintainer@example.org # same as --cc
-  suppresscc = all            # same as --suppress-cc
-  message = true              # same as --message
-  signoff = true              # same as --signoff
-  inspect-emails = true       # same as --inspect-emails
-  notes = true                # same as --notes
+  base = v2.1.0                        # same as --base
+  remote = origin                      # used if branch.<branch-name>.remote not set
+  prefix = PATCH                       # same as --patch
+  to = patches@example.org             # same as --to
+  cc = maintainer@example.org          # same as --cc
+  suppresscc = all                     # same as --suppress-cc
+  message = true                       # same as --message
+  signoff = true                       # same as --signoff
+  inspect-emails = true                # same as --inspect-emails
+  notes = true                         # same as --notes
+  blurb-template = A blurb template    # same as --blurb-template
 
 The special "default" profile name is active when no --profile command-line
 option was given.  The default profile does not set any options but can be


### PR DESCRIPTION
blurb-template is particular useful when email messages needs to
follow a pre-defined pattern.

Using it makes the default message "*** BLURB HERE ***" to be
changed to something that can be pre-defined in .gitpublish