### PR TITLE
RFC: Allow to pass arbitrary arguments to format-patch

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -183,7 +183,7 @@ def git_tag(name, annotate=None, force=False, sign=False):
 
 def git_format_patch(revlist, subject_prefix=None, output_directory=None,
                      numbered=False, cover_letter=False, signoff=False,
-                     notes=False):
+                     notes=False, extra_args=[]):
     args = ['format-patch']
     if subject_prefix:
         args += ['--subject-prefix', subject_prefix]
@@ -200,6 +200,7 @@ def git_format_patch(revlist, subject_prefix=None, output_directory=None,
     if notes:
         args += ['--notes']
     args += [revlist]
+    args += extra_args
     _git_check(*args)
 
 def git_send_email(to_list, cc_list, patches, suppress_cc, in_reply_to, dry_run=False):
@@ -490,6 +491,7 @@ def inspect_menu(tmpdir, to_list, cc_list, patches, suppress_cc, in_reply_to,
 def parse_args():
 
     parser = optparse.OptionParser(version='%%prog %s' % VERSION,
+            usage='%prog [options] -- [common format-patch options]',
             description='Prepare and store patch revisions as git tags.',
             epilog='Please report bugs to Stefan Hajnoczi <stefanha@gmail.com>.')
     parser.add_option('--annotate', dest='annotate', action='store_true',
@@ -765,7 +767,8 @@ branch.%s.pushRemote is set appropriately?  (Override with --no-url-check)''' % 
                              numbered=numbered,
                              cover_letter=message,
                              signoff=signoff,
-                             notes=notes)
+                             notes=notes,
+                             extra_args=args)
             if message:
                 cover_letter_path = os.path.join(tmpdir, '0000-cover-letter.patch')
                 lines = open(cover_letter_path).readlines()

--- a/git-publish.pod
+++ b/git-publish.pod
@@ -6,7 +6,7 @@ git-publish - Prepare and store patch revisions as git tags
 
 =head1 SYNOPSIS
 
-  git-publish [options]
+  git-publish [options] -- [common format-patch options]
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
We may want to allow passing arbitrary arguments to format-patch, to
avoid proxying all of them. Eventually, it would be nice to have them
saved in a profile too.

(the one I am insterested in are those from
https://github.com/tianocore/tianocore.github.io/wiki/Laszlo's-unkempt-git-guide-for-edk2-contributors-and-maintainers)

Signed-off-by: Marc-André Lureau <marcandre.lureau@redhat.com>