### PR TITLE
Explicit manual install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,23 @@ Hook scripts are invoked during patch preparation so that custom checks or test 
 
 ## How to install
 
+### Packages
+
 Packages are available for:
 * [Fedora](https://koji.fedoraproject.org/koji/packageinfo?packageID=25588) - `dnf install git-publish`
 * [Debian](https://packages.debian.org/buster/git-publish) and [Ubuntu](https://packages.ubuntu.com/bionic/git-publish) - `apt install git-publish`
 * [RHEL and CentOS](https://koji.fedoraproject.org/koji/packageinfo?packageID=25588) via [EPEL](https://fedoraproject.org/wiki/EPEL) - `yum install git-publish`
 
-You can also run git-publish from the source tree (useful for development):
+### Manual install
 
-```$ git clone https://github.com/stefanha/git-publish```
+You can also run git-publish from the source tree (useful for development).  Assuming `~/bin` is on `$PATH`:
+
+```
+$ git clone https://github.com/stefanha/git-publish
+$ ln -s $PWD/git-publish/git-publish ~/bin/
+```
+
+### `git publish` alias
 
 Run `git-publish --setup` to install the git alias so you can invoke `git publish` instead of `git-publish`.
 


### PR DESCRIPTION
Users may be unaware that it's safe to simply copy or symlink `git-publish` to some directory on `$PATH`. Add explicit manual install instructions to `README.md`. Addresses issue #50.