### PR TITLE
Support for multiple GPG keys + Debian Piuparts

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,7 @@ Vcs-Git: https://github.com/stefanha/git-publish.git
 
 Package: git-publish
 Architecture: all
+Multi-Arch: foreign
 Depends:
  git,
  ${misc:Depends},

--- a/git-publish
+++ b/git-publish
@@ -168,7 +168,7 @@ def git_request_pull(base, remote, signed_tag):
 def git_log(revlist):
     return _git('log', '--no-color', '--oneline', revlist)
 
-def git_tag(name, annotate=None, force=False, sign=False):
+def git_tag(name, annotate=None, force=False, sign=False, keyid=None):
     args = ['tag', '-a']
     if annotate:
         args += ['-F', annotate]
@@ -178,6 +178,8 @@ def git_tag(name, annotate=None, force=False, sign=False):
         args += ['-f']
     if sign:
         args += ['-s']
+    if keyid:
+        args += ['-k', keyid]
     args += [name]
     _git_check(*args)
 
@@ -374,7 +376,7 @@ def edit(*filenames):
     cmd.extend(filenames)
     subprocess.call(cmd)
 
-def tag(name, template, annotate=False, force=False, sign=False):
+def tag(name, template, annotate=False, force=False, sign=False, keyid=None):
     '''Edit a tag message and create the tag'''
     fd, tmpfile = None, None
 
@@ -384,7 +386,7 @@ def tag(name, template, annotate=False, force=False, sign=False):
             os.fdopen(fd, 'wb').write(os.linesep.join(template + ['']).encode('utf-8'))
             edit(tmpfile)
 
-        git_tag(name, annotate=tmpfile, force=force, sign=sign)
+        git_tag(name, annotate=tmpfile, force=force, sign=sign, keyid=keyid)
     finally:
         if tmpfile:
             os.unlink(tmpfile)
@@ -528,6 +530,8 @@ def parse_args():
                       default=False, help='tag and send as a pull request')
     parser.add_option('--sign-pull', dest='sign_pull', action='store_true',
                       help='sign tag when sending pull request')
+    parser.add_option('-k', '--keyid', dest='keyid',
+                      help='use the given GPG key when signing pull request tag')
     parser.add_option('--no-sign-pull', dest='sign_pull', action='store_false',
                       help='do not sign tag when sending pull request')
     parser.add_option('--subject-prefix', dest='prefix', default=None,
@@ -702,11 +706,17 @@ branch.%s.pushRemote is set appropriately?  (Override with --no-url-check)''' % 
         else:
             message = bool_from_str(config_cover_letter)
 
+    keyid = options.keyid
+    if keyid is None:
+        keyid_var = get_profile_var(options.profile_name, 'signingkey')
+        if keyid_var is None:
+            keyid_var = git_get_config('git-publish', 'signingkey')
+
     invoke_hook('pre-publish-tag', base)
     # Tag the tree
     if options.pull_request:
         tag_message = get_latest_tag_message(topic, ['Pull request'])
-        tag(tag_name_pull_request(topic), tag_message, annotate=message, force=True, sign=sign_pull)
+        tag(tag_name_pull_request(topic), tag_message, annotate=message, force=True, sign=sign_pull, keyid=keyid)
         git_push(remote, tag_name_pull_request(topic), force=True)
     else:
         tag_message = get_latest_tag_message(topic, [

--- a/git-publish.pod
+++ b/git-publish.pod
@@ -113,6 +113,12 @@ Sign tag when sending pull request.
 
 Do not sign tag when sending pull request.
 
+=item B<-k KEYID>
+
+=item B<--keyid=KEYID>
+
+Use the given GPG key to sign tag when sending pull request
+
 =item B<--blurb-template>
 
 Use a pre-defined blurb message for the series HEAD.
@@ -553,6 +559,10 @@ Same as the B<--no-check-url> and B<--check-url> options.
 =item B<git-publish.signPull>
 
 Same as the B<--no-sign-pull> and B<--sign-pull> options.
+
+=item B<git-publish.signingkey>
+
+Same as the B<--keyid> option.
 
 =back
 


### PR DESCRIPTION
hi Stefan,

Here 2 patches:
- fix a warning for Debian
- support for multiple GPG keys, via the '--keyid' parameter

Thanks,

Phil.