### PR TITLE
Further standardize bytes/text handling

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -46,6 +46,11 @@ class GitHookError(Exception):
 class InspectEmailsError(Exception):
     pass
 
+def to_text(data):
+    if isinstance(data, bytes):
+        return data.decode(ENCODING)
+    return data
+
 def popen_lines(cmd, **kwargs):
     '''Communicate with a Popen object and return a list of lines for stdout and stderr'''
     stdout, stderr = cmd.communicate(**kwargs)
@@ -624,7 +629,7 @@ def main():
     else:
         number = get_latest_tag_number(topic) + 1
 
-    to = set(options.to)
+    to = set([to_text(_) for _ in options.to])
     if not options.edit and not options.override_to:
         to = to.union(git_get_config_list('branch', topic, 'gitpublishto'))
         to = to.union(get_profile_var_list(options.profile_name, 'to'))
@@ -632,7 +637,7 @@ def main():
     if options.forget_cc:
         git_set_config('branch', topic, 'gitpublishcc', [])
 
-    cc = set(options.cc)
+    cc = set([to_text(_) for _ in options.cc])
     if not options.edit and not options.override_cc:
         cc = cc.union(git_get_config_list('branch', topic, 'gitpublishcc'))
         cc = cc.union(get_profile_var_list(options.profile_name, 'cc'))


### PR DESCRIPTION
Commit 395e55bec standardized the handling of data comming from the
execution of commands and when writing to files.  But, there are other
sources of data, such as from command line options, that when not
given a proper encoding, are treated as bytes.

On Python 2, there's implicit conversion when mixing unicode and bytes
(and strings are bytes on Python 2).  When that happens, the content
of the bytes part will be decode using an 'ascii' codec.  A reproducer
is as simple as:

  >>> '\xc3\xa3' + u''

To avoid this implicit conversion, we need to manually standardize
the data into unicode.

Given that this is also intended to work on Python 3, a little type
check is necessary, given that something represented with quotes and
double-quotes in Python 3, is already an "unicode string" and thus,
cannot be decode()d.

An optional (probably desirable) next step is to standardize on
to_text(), instead of calling ".decode()" on the changes introduced by
395e55bec.

Finally, the reproducer a crash that this fixes is something like:

  $ git publish [...] --cc='Philippe Mathieu-Daudé <philmd@redhat.com>'

On a system using Python 2.

CC: Philippe Mathieu-Daudé <philmd@redhat.com>
Signed-off-by: Cleber Rosa <crosa@redhat.com>