### PR TITLE
Print error message and command string when git format-patch failed

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -60,14 +60,15 @@ def popen_lines(cmd, **kwargs):
 
 def _git_check(*args):
     '''Run a git command and return a list of lines, may raise GitError'''
+    cmdstr = 'git ' + ' '.join(('"%s"' % arg if ' ' in arg else arg) for arg in args)
     if VERBOSE:
-        print('git ' + ' '.join(('"%s"' % arg if ' ' in arg else arg) for arg in args))
+        print(cmdstr)
     cmd = subprocess.Popen(['git'] + list(args),
                            stdout=subprocess.PIPE,
                            stderr=subprocess.PIPE)
     stdout, stderr = popen_lines(cmd)
     if cmd.returncode != 0:
-        raise GitError('\n'.join(stderr))
+        raise GitError('ERROR: %s\n%s' % (cmdstr, '\n'.join(stderr)))
     return stdout
 
 def _git(*args):

--- a/git-publish
+++ b/git-publish
@@ -829,7 +829,10 @@ branch.%s.pushRemote is set appropriately?  (Override with --no-url-check)''' % 
                 return 1
 
             git_send_email(to, cc, selected_patches, suppress_cc, options.in_reply_to)
-        except (GitError, GitSendEmailError, GitHookError, InspectEmailsError):
+        except (GitSendEmailError, GitHookError, InspectEmailsError):
+            return 1
+        except GitError as e:
+            print(e)
             return 1
         finally:
             if tmpdir:


### PR DESCRIPTION
First time trying to use git-publish. The local .gitpublish config has 'base' set to a branch that I only exists on the remote and I haven't checked out locally. `git-publish` silently exits without giving me any hint.

`git format-patch` errors in this case trying to access a non-existent branch. First patch prints the GitError message in this case. Second patch amends the GitError message to contain the command string too.