### PR TITLE
Fix the '--no-binary' behavior, adding default value

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -535,7 +535,7 @@ def parse_args():
     parser.add_option('-m', '--message', '--cover-letter', dest='message',
                       action='store_true', help='add a message')
     parser.add_option('--no-binary', dest='binary',
-                      action='store_false',
+                      action='store_false', default=True,
                       help='Do not output contents of changes in binary files, instead display a notice that those files changed')
     parser.add_option('--profile', '-p', dest='profile_name', default='default',
                       help='select default settings profile')


### PR DESCRIPTION
If '--no-binary' parameter is not specified, the options.binary
is None and the 'not binary' condition checked in the
git_format_patch() is True, so the '--no-binary' is always passed
to the git-format-patch.

This patch fix this issue, setting the default value
of '--no-binary' parameter to True.

Fixes: dad5ddcea3b661 ("Add --no-binary parameter")
Signed-off-by: Stefano Garzarella <sgarzare@redhat.com>