### PR TITLE
Use "git tag -l" to get tag message contents

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -156,15 +156,7 @@ def git_get_tags(pattern=None):
         return _git('tag')
 
 def git_get_tag_message(tag):
-    message = []
-    # Hide stderr when tag does not exist
-    for line in _git_with_stderr('show', '--raw', '--no-color',
-                                 '--pretty=medium', tag)[0][4:]:
-        if line.startswith('commit '):
-            message.pop()
-            return message
-        message.append(line)
-    return None
+    return _git('tag', '-l', '--format=%(contents)', tag)
 
 def git_get_remote_url(remote):
     '''Return the URL for a given remote'''


### PR DESCRIPTION
The code that splits the message when a line starts with
`commit ` breaks when the actual tag message contains a line
starting with `commit `.  Using `git tag -l --format=%(message)`
will avoid that problem.

As `git tag -l` won't error out if the tag doesn't exist, now we
can just use `_git()` instead of ignoring stderr.