### PR TITLE
Fix handling of empty tag messages

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -156,7 +156,12 @@ def git_get_tags(pattern=None):
         return _git('tag')
 
 def git_get_tag_message(tag):
-    return _git('tag', '-l', '--format=%(contents)', tag)
+    r = _git('tag', '-l', '--format=%(contents)', tag)
+    # --format=%(contents) will print an extra newline if the tag message
+    # already ends with a newline, so drop the extra line at the end:
+    if r and r[-1] == '':
+        r.pop()
+    return r
 
 def git_get_remote_url(remote):
     '''Return the URL for a given remote'''


### PR DESCRIPTION
At commit cd2b4f588428 ("Use "git tag -l" to get tag message
contents"), I accidentally broke the handling of empty tag
messages in `git_tag_get_message()`.  The function was now
returning `['']` when a tag existed with an empty message, instead
of returning an empty list.

This broke the cover letter check at main(), making git-publish
always include a cover letter even if `--no-cover-letter` was
used.

Fix this by removing the last line at `git_tag_get_message()`.