### PR TITLE
Use python3 by default to run git-publish

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # git-publish - Prepare and store patch revisions as git tags
 #


### PR DESCRIPTION
Python 2 EOL is in less than 3 months, and by using Python 3 by
default we will be able to catch python3-specific bugs before
it's too late.  Change the interpreter line to use python3.

I'm not removing the `__future__` imports because I don't know
yet if we want to drop Python 2 support immediately, or wait
until January.

Fixes #38.