### PR TITLE
Add support for --add-header argument

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -193,7 +193,7 @@ def git_tag(name, annotate=None, force=False, sign=False, keyid=None):
 
 def git_format_patch(revlist, subject_prefix=None, output_directory=None,
                      numbered=False, cover_letter=False, signoff=False,
-                     notes=False, binary=True, extra_args=[]):
+                     notes=False, binary=True, headers=[], extra_args=[]):
     args = ['format-patch']
     if subject_prefix:
         args += ['--subject-prefix', subject_prefix]
@@ -211,6 +211,10 @@ def git_format_patch(revlist, subject_prefix=None, output_directory=None,
         args += ['--notes']
     if not binary:
         args += ['--no-binary']
+
+    for header in headers:
+        args += ['--add-header', header]
+
     args += [revlist]
     args += extra_args
     _git_check(*args)
@@ -577,6 +581,8 @@ def parse_args():
                       default=False, help='Ignore any profile or saved CC emails')
     parser.add_option('--in-reply-to', "-R",
                       help='specify the In-Reply-To: of the cover letter (or the single patch)')
+    parser.add_option('--add-header', '-H', action='append', dest='headers',
+                      help='specify custom headers to git-send-email')
 
     return parser.parse_args()
 
@@ -659,6 +665,10 @@ def main():
         blurb_template = '\n'.join(get_profile_var_list(options.profile_name, 'blurb-template'))
     if not blurb_template:
         blurb_template = "*** BLURB HERE ***"
+
+    headers = options.headers
+    if not headers:
+        headers = []
 
     if options.pull_request:
         remote = git_get_config('branch', topic, 'pushRemote')
@@ -793,6 +803,7 @@ branch.%s.pushRemote is set appropriately?  (Override with --no-url-check)''' % 
                              signoff=signoff,
                              notes=notes,
                              binary=options.binary,
+                             headers=headers,
                              extra_args=args)
             if message:
                 cover_letter_path = os.path.join(tmpdir, '0000-cover-letter.patch')


### PR DESCRIPTION
Currently, git-publish fails when given the --add-header argument.
Usage: git-publish [options] -- [common format-patch options]

git-publish: error: no such option: --add-header

This change makes --add-header an official parameter.
It will be passed to format-patch, allowing the user to use
customized headers when using git-publish.