### PR TITLE
testing: set fake user name and email in .gitconfig

### DIFF
--- a/testing/0000-gitconfig-home
+++ b/testing/0000-gitconfig-home
@@ -18,7 +18,7 @@ cat >> "$HOME/.gitconfig" <<EOF
 readingworks=yes
 EOF
 
-[ "$(git config --global --show-origin --list)" = \
+[ "$(git config --global --show-origin --list | grep readingworks)" = \
   "file:$HOME/.gitconfig	gitpublishtesting.readingworks=yes" ] || \
     abort "git config is not reading .gitconfig"
 

--- a/testing/run_tests.sh
+++ b/testing/run_tests.sh
@@ -92,6 +92,14 @@ export HOME="$RESULTS_DIR/home"
 SOURCE_DIR="$RESULTS_DIR/source"
 mkdir "$SOURCE_DIR"
 cd "$SOURCE_DIR"
+
+# set fake user name and email to make git happy if system values are not set
+cat >> "$RESULTS_DIR/home/.gitconfig" <<EOF
+[user]
+	email = git-publish-tests@example.com
+	name = git-publish tests
+EOF
+
 create_git_repo
 
 setup_path


### PR DESCRIPTION
If the system git user name and email are not set, the create_git_repo() fails with this error:
```
> ./testing/run_tests.sh

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address
````

This PR set a fake git user name and email in the fake home directory to solve this issue and add a little change to testing/0000-gitconfig-home to work with this change.