### PR TITLE
Fix parse_header() for Python 3

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -425,7 +425,12 @@ def parse_header(hdr):
     for h, c in header.decode_header(hdr):
         if c is None:
             c = 'us-ascii'
-        r += h.decode(c)
+
+        if sys.version_info > (3, 0) and type(h) is str:
+            r += h
+        else:
+            r += h.decode(c)
+
     if '\n' in r:
         r = " ".join([x.strip() for x in r.splitlines()])
     return r


### PR DESCRIPTION
This patch fixes an issue when header.decode_header() is called in
Python 3 because in some cases it could return (str, NoneType) and
str doesn't provide the decode() attribute in Python 3, causing the
following exception:

Traceback (most recent call last):
  File "/home/stefano/repos/git-publish/git-publish", line 867, in <module>
    sys.exit(main())
  File "/home/stefano/repos/git-publish/git-publish", line 828, in main
    selected_patches = inspect_menu(tmpdir, to, cc, patches, suppress_cc,
  File "/home/stefano/repos/git-publish/git-publish", line 460, in inspect_menu
    print(parse_header(m['subject']))
  File "/home/stefano/repos/git-publish/git-publish", line 428, in parse_header
    r += h.decode(c)
AttributeError: 'str' object has no attribute 'decode'

Signed-off-by: Stefano Garzarella <sgarzare@redhat.com>