### PR TITLE
Fix --edit in worktree

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -307,7 +307,7 @@ def git_cover_letter_info(base, topic, to, cc, in_reply_to, number):
     cl_info += ['']
 
     cl_info += ['Version number: ' + str(number)]
-    cl_info += ['Braches:']
+    cl_info += ['Branches:']
     cl_info += ['         base:  ' + base, '         topic: ' + topic]
     cl_info += ['']
 

--- a/git-publish
+++ b/git-publish
@@ -129,7 +129,7 @@ def git_get_var(name):
     return None
 
 def git_get_current_branch():
-    git_dir = os.path.join(git_get_toplevel_dir(), '.git')
+    git_dir = git_get_git_dir()
     rebase_dir = os.path.join(git_dir, 'rebase-merge')
     if os.path.exists(rebase_dir):
         branch_path = os.path.join(rebase_dir, 'head-name')


### PR DESCRIPTION
Use the utility function which does the right thing to retrieve the
.git directory.

Signed-off-by: Marc-André Lureau <marcandre.lureau@redhat.com>