### PR TITLE
Fix --keyid option, ignore relogin-delay

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -237,7 +237,7 @@ def git_send_email(to_list, cc_list, patches, suppress_cc, in_reply_to, dry_run=
     if in_reply_to:
         args += ['--in-reply-to', in_reply_to]
     if dry_run:
-        args += ['--dry-run']
+        args += ['--dry-run', '--relogin-delay=0']
     else:
         args += ['--quiet']
     args += ['--confirm=never']

--- a/git-publish
+++ b/git-publish
@@ -194,7 +194,7 @@ def git_tag(name, annotate=None, force=False, sign=False, keyid=None):
     if sign:
         args += ['-s']
     if keyid:
-        args += ['-k', keyid]
+        args += ['--local-user', keyid]
     args += [name]
     _git_check(*args)
 

--- a/git-publish
+++ b/git-publish
@@ -184,15 +184,15 @@ def git_log(revlist):
     return _git('log', '--no-color', '--oneline', revlist)
 
 def git_tag(name, annotate=None, force=False, sign=False, keyid=None):
-    args = ['tag', '-a']
+    args = ['tag', '--annotate']
     if annotate:
-        args += ['-F', annotate]
+        args += ['--file', annotate]
     else:
-        args += ['-m', '']
+        args += ['--message', '']
     if force:
-        args += ['-f']
+        args += ['--force']
     if sign:
-        args += ['-s']
+        args += ['--sign']
     if keyid:
         args += ['--local-user', keyid]
     args += [name]


### PR DESCRIPTION
Hello Stefan,

The first patch is a fix when signing pullrequests with multiple keys,
the second a follow-up cleanup (call git-tag with long options),
I find the third patch convenient (use date in tag name),
finally the last patch improves usability when servers enforce limits on series.

Regards,

Phil.