### PR TITLE
Use --batch-size when using --relogin-delay

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -239,7 +239,7 @@ def git_send_email(to_list, cc_list, patches, suppress_cc, in_reply_to, dry_run=
     if in_reply_to:
         args += ['--in-reply-to', in_reply_to]
     if dry_run:
-        args += ['--dry-run', '--relogin-delay=0']
+        args += ['--dry-run', '--relogin-delay=0', '--batch-size=0']
     else:
         args += ['--quiet']
     args += ['--confirm=never']


### PR DESCRIPTION
Fix #85 by always specifying `--batch-size=0` when using `--relogin-delay=0`.