### PR TITLE
Specify 'batch-size' with using 'relogin' with git-send-email

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -239,7 +239,7 @@ def git_send_email(to_list, cc_list, patches, suppress_cc, in_reply_to, dry_run=
     if in_reply_to:
         args += ['--in-reply-to', in_reply_to]
     if dry_run:
-        args += ['--dry-run', '--relogin-delay=0']
+        args += ['--dry-run', '--relogin-delay=0', '--batch-size=0']
     else:
         args += ['--quiet']
     args += ['--confirm=never']


### PR DESCRIPTION
Since Git 2.17.0 [*] we must specify 'batch-size' when
using the 'relogin' option.

By simply defining it (even providing a zero value) we
fix this error:

  `batch-size` and `relogin` must be specified together (via command-line or configuration option)

[*] https://github.com/git/git/commit/9caa70697

Fixes: f504667c (Ignore any relogin delay with --dry-run)
Signed-off-by: Philippe Mathieu-Daudé <f4bug@amsat.org>