### PR TITLE
Fix --in-reply-to with more than one patches

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -618,6 +618,8 @@ def parse_args():
                       help='specify the In-Reply-To: of the cover letter (or the single patch)')
     parser.add_option('--add-header', '-H', action='append', dest='headers',
                       help='specify custom headers to git-send-email')
+    parser.add_option('--separate-send', '-S', dest='separate_send', action='store_true',
+                      default=False, help='Send patches using separate git-send-email cmd')
 
     return parser.parse_args()
 
@@ -890,7 +892,11 @@ branch.%s.pushRemote is set appropriately?  (Override with --no-url-check)''' % 
                     print('Deleted files: %s' % ' '.join(deleted))
                 return 1
 
-            git_send_email(to, cc, selected_patches, suppress_cc, options.in_reply_to)
+            if (options.separate_send):
+                for patch in selected_patches:
+                    git_send_email(to, cc, [patch], suppress_cc, options.in_reply_to)
+            else:
+                git_send_email(to, cc, selected_patches, suppress_cc, options.in_reply_to)
         except (GitSendEmailError, GitHookError, InspectEmailsError):
             return 1
         except GitError as e:


### PR DESCRIPTION
This will fix the issue of --in-reply-to when there're more than one patch to
be sent.  Before this patch, --in-reply-to will only work correctly for the 1st
patch of the patchset, but not all of them.  The problem is the command line:

  git-send-email PATCH1 PATCH2 PATCH3 ...

Will always let PATCH2/PATCH3/... to reply to PATCH 1 even if --in-reply-to is
specified.  In other words, "--in-reply-to" for git-send-email only applied
correctly on PATCH1, but not on all the patches.

Assuming we've sent the cover letter and 2 patches already, but we still want
to continue send the patches 3-5.  Before this patch, the final patchset will
look like (after both old/new patchsets):

  old cover letter
    old patch 1
    old patch 2
    new patch 3
      new patch 4
      new patch 5

After this patch, it should become:

  old cover letter
    old patch 1
    old patch 2
    new patch 3
    new patch 4
    new patch 5

Signed-off-by: Peter Xu <peterx@redhat.com>