### PR TITLE
Avoid to encode the cover letter

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -846,7 +846,7 @@ branch.%s.pushRemote is set appropriately?  (Override with --no-url-check)''' % 
 
                 blurb = os.linesep.join(message[2:])
                 body = msg.get_content().replace('*** BLURB HERE ***', blurb)
-                msg.set_content(body)
+                msg.set_payload(body)
 
                 open(cover_letter_path, 'wb').write(msg.as_bytes())
             patches = sorted(glob.glob(os.path.join(tmpdir, '*')))


### PR DESCRIPTION
git-send-email seems to be not happy with a cover letter already
encoded. In fact, git-format-patch generates it without encoding.

This problem occurs especially if 'sendemail.transferEncoding' is
not set to auto.

To avoid issues, instead of using the 'email' module, which encodes the
final result, we simply replace the text in the cover letter file
generated by git-format-patch.

Fixes: #88
Signed-off-by: Stefano Garzarella <sgarzare@redhat.com>