### PR TITLE
Do not handle the cover letter as mbox 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.8"
       - name: Install git-email
         run: sudo apt-get install -qy git-email
       - name: Run the test suite

--- a/git-publish
+++ b/git-publish
@@ -837,8 +837,13 @@ branch.%s.pushRemote is set appropriately?  (Override with --no-url-check)''' % 
                              extra_args=args)
             if message:
                 cover_letter_path = os.path.join(tmpdir, '0000-cover-letter.patch')
+
+                # email.policy.HTTP is like SMTP except that max_line_length
+                # is set to None (unlimited).
+                # This works better with git-send-email(1), avoiding issues
+                # with the subject (https://github.com/stefanha/git-publish/issues/96)
                 msg = email.message_from_binary_file(open(cover_letter_path, 'rb'),
-                                                     policy=email.policy.SMTP)
+                                                     policy=email.policy.HTTP)
 
                 subject = msg['Subject'].replace('\n', '')
                 subject = subject.replace('*** SUBJECT HERE ***', message[0])

--- a/git-publish
+++ b/git-publish
@@ -846,7 +846,11 @@ branch.%s.pushRemote is set appropriately?  (Override with --no-url-check)''' % 
 
                 blurb = os.linesep.join(message[2:])
                 body = msg.get_content().replace('*** BLURB HERE ***', blurb)
-                msg.set_content(body)
+
+                # git-format-patch(1) generates the cover letter with
+                # UTF-8 charset and Content-Transfer-Encoding=8bit.
+                # git-send-email(1) expects the same, so let's behave similarly.
+                msg.set_content(body, charset='utf-8', cte='8bit')
 
                 open(cover_letter_path, 'wb').write(msg.as_bytes())
             patches = sorted(glob.glob(os.path.join(tmpdir, '*')))

--- a/git-publish
+++ b/git-publish
@@ -846,7 +846,7 @@ branch.%s.pushRemote is set appropriately?  (Override with --no-url-check)''' % 
 
                 blurb = os.linesep.join(message[2:])
                 body = msg.get_content().replace('*** BLURB HERE ***', blurb)
-                msg.set_payload(body)
+                msg.set_content(body)
 
                 open(cover_letter_path, 'wb').write(msg.as_bytes())
             patches = sorted(glob.glob(os.path.join(tmpdir, '*')))

--- a/testing/0005-subject-line-wrap
+++ b/testing/0005-subject-line-wrap
@@ -27,6 +27,6 @@ GIT_EDITOR="cp $msgfile" git-publish --no-inspect-emails \
   --cover-letter \
   --subject-prefix="a very long long long long long long long long long test" || :
 
-echo -ne 'Subject: [a very long long long long long long long long long test 0/1] This\r\n is the message\r\n' >"$TEST_DIR/expected"
-grep --after-context=1 '^Subject:' "$coverfile" >"$TEST_DIR/found"
+echo -ne 'Subject: [a very long long long long long long long long long test 0/1] This is the message\r\n' >"$TEST_DIR/expected"
+grep '^Subject:' "$coverfile" >"$TEST_DIR/found"
 assert diff -u "$TEST_DIR/expected" "$TEST_DIR/found"

--- a/testing/0006-no-ascii-chars
+++ b/testing/0006-no-ascii-chars
@@ -1,0 +1,52 @@
+#!/bin/bash
+source "$TESTS_DIR/functions.sh"
+
+msgfile="$TEST_DIR/message"
+
+cat >"$msgfile" <<EOF
+This is the message with non-ascii characters (ąǫ)
+
+This is the description with non-ascii characters (èé).
+EOF
+
+# Copy out the cover letter before git-send-email(1) is invoked
+hookfile=".git/hooks/pre-publish-send-email"
+coverfile="$TEST_DIR/0000-cover-letter-patch"
+cat >"$hookfile" <<EOF
+#!/bin/bash
+cp "\$1/0000-cover-letter.patch" "$coverfile"
+exit 0
+EOF
+chmod 755 "$hookfile"
+
+git checkout -q -b mybranch
+
+touch foo.txt
+git add foo.txt
+git commit --author "Author with non-ascii characters (ẽã) <author@example.com>" \
+  -m "Commit with non-ascii characters (ąǫ)"
+
+GIT_EDITOR="cp $msgfile" git-publish --no-inspect-emails \
+  --to somebody@example.com \
+  -b HEAD^ \
+  --cover-letter \
+  --subject-prefix="PATCH ò" || :
+
+echo -ne \
+    'Subject: [PATCH =?utf-8?q?=C3=B2_0/1=5D_This_is_the_message_with_non-ascii_characters_=28=C4=85=C7=AB=29?=\r\n' \
+    >"$TEST_DIR/expected"
+grep '^Subject:' "$coverfile" >"$TEST_DIR/found"
+assert diff -u "$TEST_DIR/expected" "$TEST_DIR/found"
+
+echo -ne \
+    'This is the description with non-ascii characters (èé).\r\n' \
+    >"$TEST_DIR/expected"
+grep '^This is the description' "$coverfile" >"$TEST_DIR/found"
+assert diff -u "$TEST_DIR/expected" "$TEST_DIR/found"
+
+echo -ne \
+    'Author with non-ascii characters (ẽã) (1):\r\n' \
+    ' Commit with non-ascii characters (ąǫ)\r\n' \
+    >"$TEST_DIR/expected"
+grep --after-context=1 '^Author with non-ascii characters' "$coverfile" >"$TEST_DIR/found"
+assert diff -u "$TEST_DIR/expected" "$TEST_DIR/found"

--- a/testing/0007-subject-empty
+++ b/testing/0007-subject-empty
@@ -1,0 +1,34 @@
+#!/bin/bash
+source "$TESTS_DIR/functions.sh"
+
+msgfile="$TEST_DIR/message"
+
+cat >"$msgfile" <<EOF
+123456789 123456789 123456789 123456789 123456789 123456789
+
+This is the description.
+EOF
+
+# Copy out the cover letter before git-send-email(1) is invoked
+hookfile=".git/hooks/pre-publish-send-email"
+coverfile="$TEST_DIR/0000-cover-letter-patch"
+cat >"$hookfile" <<EOF
+#!/bin/bash
+cp "\$1/0000-cover-letter.patch" "$coverfile"
+exit 0
+EOF
+chmod 755 "$hookfile"
+
+git checkout -q -b mybranch
+
+GIT_EDITOR="cp $msgfile" git-publish --no-inspect-emails \
+  --to somebody@example.com \
+  -b HEAD^ \
+  --cover-letter \
+  --subject-prefix="PATCH" || :
+
+echo -ne \
+    'Subject: [PATCH 0/1] 123456789 123456789 123456789 123456789 123456789 123456789\r\n' \
+    >"$TEST_DIR/expected"
+grep '^Subject:' "$coverfile" >"$TEST_DIR/found"
+assert diff -u "$TEST_DIR/expected" "$TEST_DIR/found"

--- a/testing/fake_git
+++ b/testing/fake_git
@@ -46,7 +46,7 @@ def run_send_email(args):
 # we will never touch the real ~/.gitconfig.  See the 0000-gitconfig-home
 # test case
 PASSTHROUGH_COMMANDS = ['tag', 'rev-parse', 'symbolic-ref', 'format-patch',
-                        'config', 'checkout', 'var']
+                        'config', 'checkout', 'var', 'add', 'commit']
 
 # special commands that require some validation:
 SPECIAL_COMMANDS = {


### PR DESCRIPTION
Handling the cover letter as `mbox` has carried several issues (#88 #95 #96).
It seems that `git-send-email` doesn't expect an `mbox`, so let's handle the cover letter like a normal text, taking care of long 'Subject' line.

I also added a new test case for no-ascii characters (#96)