### PR TITLE
Don't pick up the branch description in the cover letter

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -211,6 +211,7 @@ def git_format_patch(revlist, subject_prefix=None, output_directory=None,
         args += ['--numbered']
     if cover_letter:
         args += ['--cover-letter']
+        args += ['--cover-from-description=none']
     else:
         args += ['--no-cover-letter']
     if signoff:


### PR DESCRIPTION

"git format-patch --cover-letter" populates the body with the branch
description instead of the placeholder text by default. This prevents
"git publish" to replace it with the actual body that is kept in the
<branch>-staging tag.

Just tell "git format-patch" to only populate with the placeholder text.

Fixes #105 
Signed-off-by: Greg Kurz <groug@kaod.org>