### PR TITLE
Fix linesep incorrect for Unix-like systems for cover letters

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -864,7 +864,12 @@ branch.%s.pushRemote is set appropriately?  (Override with --no-check-url)''' % 
                 # git-send-email(1) expects the same, so let's behave similarly.
                 msg.set_content(body, charset='utf-8', cte='8bit')
 
-                open(cover_letter_path, 'wb').write(msg.as_bytes())
+                # Without this, by default the policy seems to be '\r\n' always
+                # for linesep, even on Unix-like systems.  Make it explicitly
+                # to use local linesep, so it'll work right for '\n' OSs like
+                # Linux.
+                policy = msg.policy.clone(linesep=os.linesep)
+                open(cover_letter_path, 'wb').write(msg.as_bytes(policy=policy))
             patches = sorted(glob.glob(os.path.join(tmpdir, '*')))
             if options.annotate:
                 edit(*patches)


### PR DESCRIPTION
It turns out that cover letters are always using '\r\n' for linesep, even on
Unix-like systems.  One example is:

https://lore.kernel.org/lkml/20210807032521.7591-1-peterx@redhat.com/

lore.kernel.org seems to not be able to recognize '\r' chars so they're just
appended to each line.

The patch contents are all fine because they're not modified by the email
module.  Only the cover letter is affected.

Fix it by applying the linesep=os.linesep policy explicitly when re-generating
the cover letter file.  Those unwelcomed '\r' endings will go away.

I just tried this patch out, before this patch:

https://lore.kernel.org/qemu-devel/20210817013121.29941-1-peterx@redhat.com/

After this patch:

https://lore.kernel.org/qemu-devel/20210817013553.30584-1-peterx@redhat.com/