### PR TITLE
Simplify recovery after git-send-email fails halfway through the patches

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -241,7 +241,7 @@ def git_format_patch(revlist, subject_prefix=None, output_directory=None,
     args += extra_args
     _git_check(*args)
 
-def git_send_email(to_list, cc_list, patches, suppress_cc, in_reply_to, dry_run=False):
+def git_send_email(to_list, cc_list, patches, suppress_cc, in_reply_to, thread, dry_run=False):
     args = ['git', 'send-email']
     for address in to_list:
         args += ['--to', address]
@@ -251,6 +251,8 @@ def git_send_email(to_list, cc_list, patches, suppress_cc, in_reply_to, dry_run=
         args += ['--suppress-cc', suppress_cc]
     if in_reply_to:
         args += ['--in-reply-to', in_reply_to]
+    if thread is not None:
+        args += ['--thread' if thread else '--no-thread']
     if dry_run:
         args += ['--dry-run', '--relogin-delay=0', '--batch-size=0']
     else:
@@ -494,13 +496,13 @@ def git_save_email_lists(topic, to, cc, override_cc):
         git_set_config('branch', topic, 'gitpublishcc', cc)
 
 def inspect_menu(tmpdir, to_list, cc_list, patches, suppress_cc, in_reply_to,
-                 topic, override_cc):
+                 thread, topic, override_cc):
     while True:
         print('Stopping so you can inspect the patch emails:')
         print('  cd %s' % tmpdir)
         print()
         output = git_send_email(to_list, cc_list, patches, suppress_cc,
-                                in_reply_to, dry_run=True)
+                                in_reply_to, thread, dry_run=True)
         index = 0
         for f in patches:
             m = email.message_from_binary_file(open(f, 'rb'), policy=git_email_policy)
@@ -633,6 +635,10 @@ def parse_args():
                       default=False, help='Ignore any profile or saved CC emails')
     parser.add_option('--in-reply-to', "-R",
                       help='specify the In-Reply-To: of the cover letter (or the single patch)')
+    parser.add_option('--no-thread', dest='thread', action='store_false',
+                      help='do not add In-Reply-To: headers to any email')
+    parser.add_option('--thread', dest='thread', action='store_true',
+                      help='add In-Reply-To: headers to sent emails')
     parser.add_option('--add-header', '-H', action='append', dest='headers',
                       help='specify custom headers to git-send-email')
     parser.add_option('--separate-send', '-S', dest='separate_send', action='store_true',
@@ -911,8 +917,8 @@ branch.%s.pushRemote is set appropriately?  (Override with --no-check-url)''' % 
             cc.difference_update(to)
             if inspect_emails:
                 selected_patches = inspect_menu(tmpdir, to, cc, patches, suppress_cc,
-                                                options.in_reply_to, topic,
-                                                options.override_cc)
+                                                options.in_reply_to, options.thread,
+                                                topic, options.override_cc)
             else:
                 selected_patches = patches
 
@@ -932,9 +938,9 @@ branch.%s.pushRemote is set appropriately?  (Override with --no-check-url)''' % 
 
             if (options.separate_send):
                 for patch in selected_patches:
-                    git_send_email(to, cc, [patch], suppress_cc, options.in_reply_to)
+                    git_send_email(to, cc, [patch], suppress_cc, options.in_reply_to, options.thread)
             else:
-                git_send_email(to, cc, selected_patches, suppress_cc, options.in_reply_to)
+                git_send_email(to, cc, selected_patches, suppress_cc, options.in_reply_to, options.thread)
         except (GitSendEmailError, GitHookError, InspectEmailsError):
             return 1
         except GitError as e:

--- a/git-publish
+++ b/git-publish
@@ -571,6 +571,8 @@ def parse_args():
                       help='skip publicly accessible pull request URL check')
     parser.add_option('--check-url', dest='check_url', action='store_true',
                       help='check pull request URLs are publicly accessible')
+    parser.add_option('--skip', type='int', dest='skip', metavar='N', default=0,
+                      help='unselect the first N patch emails (including the cover letter if any)')
     parser.add_option('--edit', dest='edit', action='store_true',
                       default=False, help='edit message but do not tag a new version')
     parser.add_option('--no-inspect-emails', dest='inspect_emails',
@@ -895,6 +897,7 @@ branch.%s.pushRemote is set appropriately?  (Override with --no-check-url)''' % 
                 open(cover_letter_path, 'wb').write(msg.as_bytes(unixfrom=True,
                                                                  policy=git_email_policy))
             patches = sorted(glob.glob(os.path.join(tmpdir, '*')))
+            del patches[:options.skip]
             if options.annotate:
                 edit(*patches)
             if cc_cmd:
@@ -916,6 +919,7 @@ branch.%s.pushRemote is set appropriately?  (Override with --no-check-url)''' % 
             invoke_hook('pre-publish-send-email', tmpdir)
 
             final_patches = sorted(glob.glob(os.path.join(tmpdir, '*')))
+            del final_patches[:options.skip]
             if final_patches != patches:
                 added = set(final_patches).difference(set(patches))
                 deleted = set(patches).difference(set(final_patches))

--- a/git-publish.pod
+++ b/git-publish.pod
@@ -194,7 +194,19 @@ Ignore any profile or saved Cc: email addresses.
 
 =item B<--in-reply-to=IN_REPLY_TO>
 
-Specify the In-Reply-To: of the cover letter (or the single patch).
+Specify the In-Reply-To: of the first email, or of all emails if --no-thread is
+given or is otherwise the default.
+
+=item B<--no-thread>
+
+Do not add In-Reply-To: and References: headers to any email.  This may be the
+default depending on your L<git-send-email(1)> configuration.
+
+=item B<--thread>
+
+Add In-Reply-To: and References: headers to sent emails.  This may be the
+default depending on your L<git-send-email(1)> configuration, which also
+controls whether each email refers to the previous email or to the first email.
 
 =back
 

--- a/git-publish.pod
+++ b/git-publish.pod
@@ -63,6 +63,11 @@ Do not check whether the pull request URL is publicly accessible.
 
 Check whether the pull request URL is publicly accessible.  This is the default.
 
+=item B<--skip=N>
+
+Unselect the first N patch emails (including the cover letter if any).  If
+negative, select only the last -N patches.
+
 =item B<--edit>
 
 Edit message but do not tag a new version.  Use this to draft the cover letter before actually tagging a new version.


### PR DESCRIPTION
If git-send-email fails after sending only some (say N) of the patches, invoking git-publish to send the rest currently involves:

- Manually choosing [s] and removing the first N lines;
- Manually adding In-Reply-To: and References: headers to every remaining patch pointing at the already-sent cover letter (assuming we want every email to be a reply to the first).

Add a couple options to streamline this process, so that if git-send-email fails after sending 3 out of 5 emails, we can simply do:

```console
$ git publish --skip=3 --no-thread --in-reply-to=20220513155418.2486450-1-afaria@redhat.com
```