### PR TITLE
General cleanups

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -15,7 +15,6 @@ import email
 import email.policy
 import os
 import glob
-import shlex
 import sys
 import optparse
 import re

--- a/git-publish
+++ b/git-publish
@@ -437,10 +437,8 @@ def edit(*filenames):
     subprocess.call(cmd)
 
 def edit_content(content, suffix):
-    fd, tmpfile = None, None
-
+    fd, tmpfile = tempfile.mkstemp(suffix=suffix)
     try:
-        fd, tmpfile = tempfile.mkstemp(suffix=suffix)
         with os.fdopen(fd, 'wb') as f:
             f.write(content.encode(TEXTFILE_ENCODING))
         edit(tmpfile)
@@ -448,8 +446,7 @@ def edit_content(content, suffix):
             new_content = f.read()
         return new_content.decode(TEXTFILE_ENCODING)
     finally:
-        if tmpfile:
-            os.unlink(tmpfile)
+        os.unlink(tmpfile)
 
 def tag(name, template, annotate=False, force=False, sign=False, keyid=None):
     '''Edit a tag message and create the tag'''

--- a/git-publish
+++ b/git-publish
@@ -11,7 +11,6 @@
 # This work is licensed under the MIT License.  Please see the LICENSE file or
 # http://opensource.org/licenses/MIT.
 
-from __future__ import print_function, unicode_literals
 from io import open
 import email
 import email.policy

--- a/git-publish
+++ b/git-publish
@@ -441,9 +441,8 @@ def edit_content(content, suffix):
 
     try:
         fd, tmpfile = tempfile.mkstemp(suffix=suffix)
-        fd_opened = os.fdopen(fd, 'wb')
-        fd_opened.write(content.encode(TEXTFILE_ENCODING))
-        fd_opened.close()
+        with os.fdopen(fd, 'wb') as f:
+            f.write(content.encode(TEXTFILE_ENCODING))
         edit(tmpfile)
         with open(tmpfile, "rb") as f:
             new_content = f.read()
@@ -460,9 +459,8 @@ def tag(name, template, annotate=False, force=False, sign=False, keyid=None):
         if annotate:
             new_content = edit_content(os.linesep.join(template + ['']), '.txt')
             fd, tmpfile = tempfile.mkstemp()
-            fd_opened = os.fdopen(fd, 'wb')
-            fd_opened.write(new_content.encode(GIT_ENCODING))
-            fd_opened.close()
+            with os.fdopen(fd, 'wb') as f:
+                f.write(new_content.encode(GIT_ENCODING))
 
         git_tag(name, annotate=tmpfile, force=force, sign=sign, keyid=keyid)
     finally:

--- a/git-publish
+++ b/git-publish
@@ -146,7 +146,8 @@ def git_get_current_branch():
         branch_path = os.path.join(rebase_dir, 'head-name')
         prefix = 'refs/heads/'
         # Path names are encoded in UTF-8 normalization form C.
-        branch = open(branch_path, encoding=GIT_ENCODING).read().strip()
+        with open(branch_path, encoding=GIT_ENCODING) as f:
+            branch = f.read().strip()
         if branch.startswith(prefix):
             return branch[len(prefix):]
         return branch
@@ -444,9 +445,8 @@ def edit_content(content, suffix):
         fd_opened.write(content.encode(TEXTFILE_ENCODING))
         fd_opened.close()
         edit(tmpfile)
-        fd_opened = open(tmpfile, "rb")
-        new_content = fd_opened.read()
-        fd_opened.close()
+        with open(tmpfile, "rb") as f:
+            new_content = f.read()
         return new_content.decode(TEXTFILE_ENCODING)
     finally:
         if tmpfile:

--- a/git-publish
+++ b/git-publish
@@ -11,7 +11,6 @@
 # This work is licensed under the MIT License.  Please see the LICENSE file or
 # http://opensource.org/licenses/MIT.
 
-from io import open
 import email
 import email.policy
 import os

--- a/git-publish
+++ b/git-publish
@@ -500,8 +500,9 @@ def inspect_menu(tmpdir, to_list, cc_list, patches, suppress_cc, in_reply_to,
         output = git_send_email(to_list, cc_list, patches, suppress_cc,
                                 in_reply_to, thread, dry_run=True)
         index = 0
-        for f in patches:
-            m = email.message_from_binary_file(open(f, 'rb'), policy=git_email_policy)
+        for patch in patches:
+            with open(patch, 'rb') as f:
+                m = email.message_from_binary_file(f, policy=git_email_policy)
             if 'Subject' in m:
                 print(m['Subject'].strip())
             # Print relevant 'Adding cc' lines from the git-send-email --dry-run output
@@ -882,8 +883,8 @@ branch.%s.pushRemote is set appropriately?  (Override with --no-check-url)''' % 
                 # is set to None (unlimited).
                 # This works better with git-send-email(1), avoiding issues
                 # with the subject (https://github.com/stefanha/git-publish/issues/96)
-                msg = email.message_from_binary_file(open(cover_letter_path, 'rb'),
-                                                     policy=git_email_policy)
+                with open(cover_letter_path, 'rb') as f:
+                    msg = email.message_from_binary_file(f, policy=git_email_policy)
 
                 subject = msg['Subject'].replace('\n', '')
                 subject = subject.replace('*** SUBJECT HERE ***', message[0])
@@ -897,8 +898,9 @@ branch.%s.pushRemote is set appropriately?  (Override with --no-check-url)''' % 
                 # git-send-email(1) expects the same, so let's behave similarly.
                 msg.set_content(body, charset='utf-8', cte='8bit')
 
-                open(cover_letter_path, 'wb').write(msg.as_bytes(unixfrom=True,
-                                                                 policy=git_email_policy))
+                with open(cover_letter_path, 'wb') as f:
+                    f.write(msg.as_bytes(unixfrom=True, policy=git_email_policy))
+
             patches = sorted(glob.glob(os.path.join(tmpdir, '*')))
             del patches[:options.skip]
             if options.annotate:


### PR DESCRIPTION
- Fix usage of `open()` and `os.fdopen()` to ensure that files are closed properly.
- Use `open()` instead of `io.open()` (python 2 leftover)
- Idiomatic use of try-finally to cleanup temporary file
- Remove unneeded `__future__` imports (python 2 leftover)
- Remove unused import