### PR TITLE
Check the base branch

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -192,6 +192,14 @@ def git_get_remote_url(remote):
 def git_request_pull(base, remote, signed_tag):
     return _git_check('request-pull', base, remote, signed_tag)
 
+def git_branch_exists(branch):
+    '''Check if the given branch exists'''
+    try:
+        _git_check('rev-parse', '-q', '--verify', branch)
+        return True
+    except GitError:
+        return False
+
 def git_log(revlist):
     return _git('log', '--no-color', '--oneline', revlist)
 
@@ -690,6 +698,10 @@ def main():
         base = git_get_config('git-publish', 'base')
     if not base:
         base = 'master'
+
+    if not git_branch_exists(base):
+        print('Branch "%s" does not exist. Forgot to pass --base ?' % base)
+        return 1
 
     if topic == base:
         print('Please use a topic branch, cannot version the base branch (%s)' % base)


### PR DESCRIPTION
When the base branch does not exist, git-publish produces a pretty cryptic error:
ERROR: git format-patch --subject-prefix PATCH --output-directory /tmp/tmps35kpt7n --no-cover-letter master.. fatal: ambiguous argument 'master..': unknown revision or path not in the working tree. Use '--' to separate paths from revisions, like this: 'git <command> [<revision>...] -- [<file>...]'

Improve the situation a bit with an early check, and some hint.

Signed-off-by: Marc-André Lureau <marcandre.lureau@redhat.com>