### PR TITLE
Add arg that forwards args to git-send-email command

### DIFF
--- a/git-publish
+++ b/git-publish
@@ -247,7 +247,7 @@ def git_format_patch(revlist, subject_prefix=None, output_directory=None,
     args += extra_args
     _git_check(*args)
 
-def git_send_email(to_list, cc_list, patches, suppress_cc, in_reply_to, thread, dry_run=False):
+def git_send_email(to_list, cc_list, patches, suppress_cc, in_reply_to, thread, send_email_args=[], dry_run=False):
     args = ['git', 'send-email']
     for address in to_list:
         args += ['--to', address]
@@ -259,6 +259,7 @@ def git_send_email(to_list, cc_list, patches, suppress_cc, in_reply_to, thread, 
         args += ['--in-reply-to', in_reply_to]
     if thread is not None:
         args += ['--thread' if thread else '--no-thread']
+    args += send_email_args
     if dry_run:
         args += ['--dry-run', '--relogin-delay=0', '--batch-size=0']
     else:
@@ -496,13 +497,13 @@ def git_save_email_lists(topic, to, cc, override_cc):
         git_set_config('branch', topic, 'gitpublishcc', cc)
 
 def inspect_menu(tmpdir, to_list, cc_list, patches, suppress_cc, in_reply_to,
-                 thread, topic, override_cc):
+                 thread, topic, override_cc, send_email_args=[]):
     while True:
         print('Stopping so you can inspect the patch emails:')
         print('  cd %s' % tmpdir)
         print()
-        output = git_send_email(to_list, cc_list, patches, suppress_cc,
-                                in_reply_to, thread, dry_run=True)
+        output = git_send_email(to_list, cc_list, patches, suppress_cc, in_reply_to,
+                                thread, send_email_args=send_email_args, dry_run=True)
         index = 0
         for patch in patches:
             with open(patch, 'rb') as f:
@@ -645,6 +646,8 @@ def parse_args():
                       help='specify custom headers to git-send-email')
     parser.add_option('--separate-send', '-S', dest='separate_send', action='store_true',
                       default=False, help='Send patches using separate git-send-email cmd')
+    parser.add_option('--send-email-args', action='append', default=[],
+                      help="Arguments forwarded to git-send-email")
 
     return parser.parse_args()
 
@@ -925,7 +928,7 @@ branch.%s.pushRemote is set appropriately?  (Override with --no-check-url)''' % 
             if inspect_emails:
                 selected_patches = inspect_menu(tmpdir, to, cc, patches, suppress_cc,
                                                 options.in_reply_to, options.thread,
-                                                topic, options.override_cc)
+                                                topic, options.override_cc, send_email_args=options.send_email_args)
             else:
                 selected_patches = patches
 
@@ -945,9 +948,11 @@ branch.%s.pushRemote is set appropriately?  (Override with --no-check-url)''' % 
 
             if (options.separate_send):
                 for patch in selected_patches:
-                    git_send_email(to, cc, [patch], suppress_cc, options.in_reply_to, options.thread)
+                    git_send_email(to, cc, [patch], suppress_cc, options.in_reply_to, options.thread,
+                                   send_email_args=options.send_email_args)
             else:
-                git_send_email(to, cc, selected_patches, suppress_cc, options.in_reply_to, options.thread)
+                git_send_email(to, cc, selected_patches, suppress_cc, options.in_reply_to, options.thread,
+                               send_email_args=options.send_email_args)
         except (GitSendEmailError, GitHookError, InspectEmailsError):
             return 1
         except GitError as e:

--- a/git-publish
+++ b/git-publish
@@ -513,7 +513,7 @@ def inspect_menu(tmpdir, to_list, cc_list, patches, suppress_cc, in_reply_to,
             # Print relevant 'Adding cc' lines from the git-send-email --dry-run output
             while index < len(output) and len(output[index]):
                 line = output[index].replace('\r', '')
-                if line.find('Adding cc') != -1:
+                if line.find('Adding ') != -1:
                     print('  ' + line)
                 index += 1
             index += 1

--- a/git-publish.pod
+++ b/git-publish.pod
@@ -208,6 +208,11 @@ Add In-Reply-To: and References: headers to sent emails.  This may be the
 default depending on your L<git-send-email(1)> configuration, which also
 controls whether each email refers to the previous email or to the first email.
 
+=item B<--send-email-args>
+
+List of arguments that are forwarded to the git-send-email call. You can add as
+many arguments as you need by using consecutive L<--send-email-args> arguments.
+
 =back
 
 =head1 DISCUSSION
@@ -419,6 +424,11 @@ One can attach notes to a commit with `git notes add <object>`. For having the
 notes "following" a commit on rebase operation, you can use
 `git config notes.rewriteRef refs/notes/commits`. For more information,
 give a look at L<git-notes(1)>.
+
+To have L<git-send-email> add a cc list to individual patch emails we use:
+
+  $ git-publish --cc patches@example.org --send-email-args="--cc-cmd" --send-email-args="SCRIPT"
+
 
 =head2 Creating profiles for frequently used projects
 


### PR DESCRIPTION
Implement a way to forward args down to the git-send-email call. In this way you can access all git-send-emails features.

In my case I wanted to the cc-cmd to set cc per patch email instead for all of them. And though I can do what I want after applying this patch, it opens the door for using all kinds of features from git-send-email.

The only downside I see is that there might be clashes with git-publish specific options. If this is a concern, I can try to mitigate specific clashes.

comments are appreciated